### PR TITLE
Lists branches without repetition, not showing the current branch

### DIFF
--- a/git-switch.rb
+++ b/git-switch.rb
@@ -32,7 +32,7 @@ case options[:show]
 when :modified
   branches = `git for-each-ref --format="%(refname:short)" --sort='-authordate' refs/heads --count #{options[:count]}`.split
 else
-  branches = `git reflog | grep "checkout: moving" | cut -d' ' -f8 | uniq | head -#{options[:count] + 1}`.split.drop(1)
+  branches = `git reflog | grep "checkout: moving" | cut -d' ' -f8`.split.uniq.drop(1).take(options[:count])
 end
 
 exit if branches.count == 0


### PR DESCRIPTION
The shell utility uniq only removes lines if they're adjacent while
uniq in ruby removes all duplication in the array.