### PR TITLE
Add option to set the amount of branches to show

### DIFF
--- a/git-switch.rb
+++ b/git-switch.rb
@@ -19,6 +19,10 @@ if `git config --get switch.order`.chomp == "checked-out"
   options[:show] = :checkout
 end
 
+if (count = `git config --get switch.count`.chomp.to_i) > 0
+  options[:count] = count
+end
+
 begin
   OptionParser.new do |opts|
     opts.banner = "Usage: git switch [options]"


### PR DESCRIPTION
Allow to change default count option by adding a git configuration. Now
you can do `git config --add switch.count <number>`

cc/ @marpo60 @eldano 