### PR TITLE
Man page

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Marcelo Domínguez, Santiago Ferreira
+Copyright (c) 2014, 2015 Marcelo Domínguez, Santiago Ferreira
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-switch
 
-List latests used branches
+Allows to checkout easily previously used branches. It can list branches by checked out date or by modified date, that is, branches with newest commits.
 
 ## Synopsis
 
@@ -29,14 +29,20 @@ of the branches in the list.
 | `-o` `--checked-out`    | Show recently checked out branches. By default it lists by branch's modified date. |
 | `-m` `--modified`       | Show last modified branches |
 | `-i` `--no-interactive` | Don't use interactive mode. Interactive by default. |
-| `-c` `--count <number>` | Show number of branches. |
+| `-c` `--count <number>` | Show number of branches. By default it shows nine.|
 
 ## Configurations
 
 You can configure git switch to do "checked-out" order by default
 
-```
+```sh
 git config --add switch.order checked-out
+```
+
+You can also configure the number of branches to show
+
+```sh
+git config --add switch.count 5
 ```
 
 ## Installation

--- a/git-switch.man
+++ b/git-switch.man
@@ -1,0 +1,34 @@
+.TH GIT-SWITCH 1 "7 April 15"
+.SH NAME
+git-switch \- List latests used branches
+.SH SYNOPSIS
+git-switch [ -o | -m ] [ -i ] [ -c count ]
+.SH DESCRIPTION
+Allows to checkout easily previously used branches. It can list branches by checked out date or by modified date, that is, branches with newest commits.
+.SH OPTIONS
+.TP
+.BR \-o ", " \-\-checked-out
+Show recently checked out branches. By default it lists by branch's modified date.
+.TP
+.BR \-m ", " \-\-modified
+Show last modified branches.
+.TP
+.BR \-i ", " \-\-no-interactive
+Don't use interactive mode. Interactive by default.
+.TP
+.BR \-c " " \fINUMBER\fR ", " \-\-count " " \fINUMBER\fR
+Show \fINUMBER\fP of branches.
+.SH CONFIGURATION
+See git-config(1) for core variables.
+.TP
+\fBswitch.order\fP
+If the value is \fIchecked-out\fP, it will show branches listed by recently checked out date. The default is \fImodified\fP.
+.TP
+\fBswitch.count\fP
+Number of branches to show. By default is nine.
+.SH "SEE ALSO"
+\fBgit-checkout(1)\fP
+.SH COPYRIGHT
+Copyright (c) 2014, 2015 Marcelo Dominguez, Santiago Ferreira
+
+git-switch is licensed under the MIT license.


### PR DESCRIPTION
This PR adds a man page for git-switch. The idea is to install the man page using the Homebrew formula for now.

- [x] Write man page
- [x] Update README text using man page texts
- [x] Update LICENSE to add 2015 to the copyright notice

This fixes #20 