### PR TITLE
Make bash completion to behave more closely to git completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to checkout previous branch
 | `-o` `--checked-out`    | Show recently checked out branches. By default it lists by branch's modified date. |
 | `-m` `--modified`       | Show last modified branches |
 | `-i` `--no-interactive` | Don't use interactive mode. Interactive by default. |
-| `-c` `--count <number>` | Show number of branches. By default it shows nine.|
+| `-c` `--count=<number>` | Show number of branches. By default it shows nine.|
 | `-v` `--version`        | Show version number and quit |
 
 ## Configurations

--- a/git-switch-completion.bash
+++ b/git-switch-completion.bash
@@ -3,7 +3,14 @@
 _git_switch()
 {
   local cur=${COMP_WORDS[COMP_CWORD]}
-  local options="--checked-out --count --help --modified --non-interactive"
+  local options="--checked-out --count= --help --modified --non-interactive --version"
 
-  COMPREPLY=( $(compgen -W "$options" -- $cur) )
+  case $cur in
+    --*=)
+      # Avoid '--count=--count' edge cases
+      ;;
+    --*)
+      COMPREPLY=( $(compgen -W "$options" -- $cur) )
+      ;;
+  esac
 }

--- a/git-switch.man
+++ b/git-switch.man
@@ -16,7 +16,7 @@ Show last modified branches.
 .BR \-i ", " \-\-no-interactive
 Don't use interactive mode. Interactive by default.
 .TP
-.BR \-c " " \fINUMBER\fR ", " \-\-count " " \fINUMBER\fR
+.BR \-c " " \fINUMBER\fR ", " \-\-count =\fINUMBER\fR
 Show \fINUMBER\fP of branches.
 .TP
 .BR \-v ", " \--version

--- a/git-switch.rb
+++ b/git-switch.rb
@@ -36,7 +36,7 @@ class Options
         options[:interactive] = false
       end
 
-      opts.on("-c", "--count <number>", Integer, "Show number of branches") do |number|
+      opts.on("-c", "--count=<number>", Integer, "Show number of branches") do |number|
         options[:count] = number
       end
     end.parse!(args)


### PR DESCRIPTION
This commit fixes three different issues

1. `--version` option was missing
2. Adds `=` sign to `--count` option in completion and documentation
3. Suggest long options only when completing `--` string

Fixes #27 